### PR TITLE
Force to render ExitRelay for relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Set true if you want your relay to be an exit, with the default
 exit policy (or whatever exit policy you set below).
 (If `torrc_reduced_exit_policy`, `torrc_exit_policies`, or `torrc_ipv6_exit` are set, relays are exits.
 If none of these options are set, relays are non-exits.)
+> Note that in some Tor versions relays were exits by default but this
+> Ansible role will explicitly set them to non-exits unless you configure
+> it otherwise.
 - `torrc_ipv6_exit: false`
 Set true if you want your relay to allow IPv6 exit traffic.
 (Relays do not allow any exit traffic by default.)

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -87,7 +87,7 @@ DirPortFrontPage {{ torrc_dir_port_front_page }}
 MyFamily {{ torrc_my_family }}
 {% endif %}
 
-{%- if torrc_exit_relay %}
+{%- if torrc_or_ports %}
 ExitRelay {{ renderbool(torrc_exit_relay) }}
 {% endif %}
 


### PR DESCRIPTION
Whenever the Tor daemon is being configured as a relay,
force the rendering of the ExitRelay option regardless
of what has been configured.

This is to prevent a variable behaviour of the template
across different Tor daemon versions since the default
ExitRelay option changed over time.